### PR TITLE
Fix deserialization of werk cache with no build table

### DIFF
--- a/werk-runner/cache.rs
+++ b/werk-runner/cache.rs
@@ -7,6 +7,7 @@ use werk_util::Symbol;
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct WerkCache {
     /// Per-build-target caches.
+    #[serde(default)]
     pub build: BTreeMap<Absolute<werk_fs::PathBuf>, TargetOutdatednessCache>,
 }
 


### PR DESCRIPTION
The `build` table is marked as `implicit`, so it is not emitted if it is empty. Which resulted in the following error message when building:

```
2025-02-01T10:32:46.599944Z ERROR werk_runner::workspace: Failed to parse workspace cache: TOML parse error at line 1, column 1
  |
1 | # Generated by werk. It can be safely deleted.
  | ^
missing field `build`
```