### PR TITLE
Document minimum rust version for werk-cli

### DIFF
--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -4,6 +4,10 @@
 time. That said, `werk` is a self-contained binary that can easily be
 transferred between machines.
 
+## Installation Dependencies
+
+- `rustc` >= 1.83.0
+
 ## Installation steps
 
 1. `git clone https://github.com/simonask/werk`

--- a/werk-cli/Cargo.toml
+++ b/werk-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "werk-cli"
 version = "0.1.0"
 edition = "2021"
 build = "build.rs"
+rust-version = "1.83.0"
 
 [[bin]]
 name = "werk"


### PR DESCRIPTION
Specifies a minimum rust version to werk-cli/Cargo.toml due to usage of Option.get_or_insert_default(). This function was added in rust 1.83.0.

Adds an Installation Dependencies section to highlight this requirement.