### PR TITLE
Fix depfile generation flag with -MMD

### DIFF
--- a/book/src/examples/c.md
+++ b/book/src/examples/c.md
@@ -57,7 +57,7 @@ build "%.o" {
     let flags = [cflags, "-I<include-path>"]
 
     # Generate depfile and object file in the same command
-    run "{cc} -MM -MT <in> -MF <depfile> -c {flags*} -o <out> <in>"
+    run "{cc} -MMD -MT <in> -MF <depfile> -c {flags*} -o <out> <in>"
 }
 
 # Build rule for the main executable


### PR DESCRIPTION
Both clang and gcc have different flags to generate depfiles. Some of these flags imply the use of -E which only runs the preprocessor instead of also compiling objects.

-MM implies -E which will generate empty object files. -MMD should be used instead