### PR TITLE
Filter dirs from workspace files

### DIFF
--- a/werk-runner/workspace.rs
+++ b/werk-runner/workspace.rs
@@ -139,6 +139,9 @@ impl<'a> Workspace<'a> {
             IndexMap::with_capacity_and_hasher(1024, ahash::RandomState::default());
 
         for entry in io.glob_workspace(&project_root, &settings.glob)? {
+            if entry.path.is_dir() {
+                continue;
+            }
             if entry.path.file_name() == Some(WERK_CACHE_FILENAME.as_ref()) {
                 return Err(Error::ClobberedWorkspace(entry.path.into_inner()));
             }


### PR DESCRIPTION
I'm not sure if this is this appropriate way to resolve https://github.com/simonask/werk/issues/41.

I was getting conflicts where `<out>` would resolve to a dir path inside the workspace, instead of a filepath inside the target directory.

This PR would remove directories from the workspace files. However, I don't know if it's preferable that the conflict is resolved elsewhere (i.e. `Workspace::resolve_path`), or if it's intended that werk tracks dirs in the workspace.