### PR TITLE
Detect path resolution ambiguity

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -27,6 +27,7 @@
   - [Variables](./language/variables.md)
   - [Expressions](./language/expressions.md)
   - [String Interpolation](./language/strings.md)
+  - [Path resolution](./language/path_resolution.md)
   - [Patterns](./language/patterns.md)
   - [Recipe commands](./language/recipe_commands.md)
   - [Built-in variables](./language/builtins.md)

--- a/book/src/language/path_resolution.md
+++ b/book/src/language/path_resolution.md
@@ -1,0 +1,41 @@
+# Path resolution
+
+Werk supports translating [abstract paths](../paths.md) into native OS paths in
+string interpolations, using the special `"<...>"` interpolation syntax.
+
+Normal string interpolations `"{...}"` are always "verbatim" - the interpolation
+is performed literally.
+
+However, string interpolation with `<...>` performs extra logic to obtain a
+native OS path whenever it occurs, and this logic is sensitive to the
+surroundings of the interpolation, as well as the presence of build recipe
+rules.
+
+Consider the following Werkfile:
+
+```werk
+# c:\workspace
+#    target\
+#    dir\
+#    foo.txt
+
+config out-dir = "target"
+
+let input = "foo.txt"
+let output = "bar.txt"
+let dir = "dir"
+```
+
+- `"<input>"` resolves to `c:\workspace\foo.txt`, because `foo.txt` exists in
+  the workspace.
+- `"<output>"` resolves to `c:\workspace\target\bar.txt`, because `bar.txt`
+  does not exist in the workspace.
+- `"<input:out-dir>"` resolves to `c:\workspace\target\foo.txt`, because it is
+  explicitly requested.
+- `"<output:workspace>"` resolves to `c:\workspace\bar.txt`, because it is
+  explicitly requested, even though the file does not exist in the workspace.
+- `"<dir>"` resolves to `c:\workspace\dir`, even though it is a directory.
+- When an `<...>` interpolation would match a file in the workspace, but also
+  matches a build recipe, `werk` fails with an error describing the ambiguity.
+  The path can be disambiguated by using `:out-dir` or `:workspace` to
+  disambiguate path resolution.

--- a/book/src/language/strings.md
+++ b/book/src/language/strings.md
@@ -97,6 +97,12 @@ they are applied in order.
   produces the file-without-directory part of the path.
 - `{...:ext}`: When the stem refers to an [abstract path](../paths.md), produces
   the file extension (without the `.`) of the path.
+- `<...:out-dir>`: Disambiguate [native path resolution](./path_resolution.md)
+  to produce a path in the output directory. Does nothing in `{...}`
+  interpolations.
+- `<...:workspace>`: Disambiguate [native path resolution](./path_resolution.md)
+  to produce a path in the workspace directory. Does nothing in `{...}`
+  interpolations.
 
 ## String interpolation example
 

--- a/book/src/paths.md
+++ b/book/src/paths.md
@@ -14,12 +14,13 @@ syntax](./language/strings.md#string-interpolation) `"<var>"`, the abstract path
 stored in `var` will be converted to a native absolute path within the
 workspace.
 
-Native path resolution may resolve to either an input file in the workspace or a
-generated file in the output directory. This check is based on existence: If the
-file is found in the workspace, it resolves to the file inside the workspace.
-Otherwise, it is assumed that a build recipe will generate the file in the
-output directory, and it resolves to an absolute path inside the output
-directory, mirroring the directory structure of the workspace.
+[Native path resolution](./language/path_resolution.md) may resolve to either an
+input file in the workspace or a generated file in the output directory. This
+check is based on existence: If the file is found in the workspace, it resolves
+to the file inside the workspace. Otherwise, it is assumed that a build recipe
+will generate the file in the output directory, and it resolves to an absolute
+path inside the output directory, mirroring the directory structure of the
+workspace.
 
 In general, build recipes should take care to not clobber the workspace and only
 generate files with paths that coincide with paths in the workspace.

--- a/examples/issue-41/Werkfile
+++ b/examples/issue-41/Werkfile
@@ -1,0 +1,15 @@
+config out-dir = "../../target/examples/issue-41"
+config default = "build"
+
+build "foo" {
+    info "<out>"
+}
+
+build "bar" {
+    info "<out>"
+}
+
+task build {
+    build "foo"
+    build "bar"
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -43,6 +43,10 @@ name = "test_outdatedness"
 path = "test_outdatedness.rs"
 
 [[test]]
+name = "test_path_resolution"
+path = "test_path_resolution.rs"
+
+[[test]]
 name = "test_cases"
 path = "test_cases.rs"
 

--- a/tests/test_cases.rs
+++ b/tests/test_cases.rs
@@ -42,7 +42,7 @@ async fn evaluate_check(file: &std::path::Path) -> Result<(), anyhow::Error> {
             if let Some(captures) = regexes.file.captures(line) {
                 let filename = captures.get(1).unwrap().as_str();
                 let content = captures.get(2).unwrap().as_str();
-                let path = workspace_file(filename);
+                let path = test.workspace_path(filename.split('/'));
                 insert_fs(
                     &mut fs,
                     &path,
@@ -95,7 +95,7 @@ async fn evaluate_check(file: &std::path::Path) -> Result<(), anyhow::Error> {
 
         let fs = test.io.filesystem.lock();
         for (filename, contents) in &check_files {
-            let out_file = output_file(filename);
+            let out_file = test.output_path(filename.split('/'));
             let (_entry, data) = read_fs(&fs, &out_file)?;
             assert_eq!(
                 data, *contents,

--- a/tests/test_expressions.rs
+++ b/tests/test_expressions.rs
@@ -1,26 +1,11 @@
-use std::sync::Arc;
-
 use werk_runner::Value;
 
 use tests::mock_io::*;
 use werk_util::Symbol;
 
 fn evaluate_global(source: &str, global_variable_name_to_check: &str) -> Value {
-    let path = std::path::Path::new("test input");
-    let ast = werk_parser::parse_werk(source)
-        .map_err(|err| anyhow::Error::msg(err.with_location(path, source).to_string()))
-        .unwrap();
-    let render = Arc::new(MockRender::default());
-    let io = Arc::new(MockIo::default());
-    io.with_default_workspace_dir();
-    let workspace = werk_runner::Workspace::new(
-        &ast,
-        &*io,
-        &*render,
-        test_workspace_dir().to_path_buf(),
-        &test_workspace_settings(&[]),
-    )
-    .unwrap();
+    let test = Test::new(source).unwrap();
+    let workspace = test.create_workspace(&[]).unwrap();
     workspace
         .manifest
         .globals

--- a/tests/test_path_resolution.rs
+++ b/tests/test_path_resolution.rs
@@ -104,7 +104,7 @@ build "explicit" {
     from "explicit"
     run {
         # Cannot get here.
-        copy "<in>" to "<out>"
+        copy "{in}" to "{out}"
     }
 }
     "#;

--- a/tests/test_path_resolution.rs
+++ b/tests/test_path_resolution.rs
@@ -1,0 +1,158 @@
+use macro_rules_attribute::apply;
+use tests::mock_io::*;
+use werk_fs::Absolute;
+use werk_runner::{Runner, TaskId, Value};
+use werk_util::Symbol;
+
+#[test]
+fn test_path_resolution() {
+    static WERK: &str = r#"
+let exists = "foo";
+let exists-not = "bar";
+
+let exists-resolved = "<exists>"
+let exists-explicit-out-dir = "<exists:out-dir>"
+let exists-explicit-workspace = "<exists:workspace>"
+
+let exists-not-resolved = "<exists-not>"
+let exists-not-explicit-out-dir = "<exists-not:out-dir>"
+let exists-not-explicit-workspace = "<exists-not:workspace>"
+"#;
+
+    _ = tracing_subscriber::fmt::try_init();
+
+    let test = match Test::new(WERK) {
+        Ok(test) => test,
+        Err(err) => {
+            eprintln!("{}", err.with_location(std::path::Path::new("input"), WERK));
+            panic!("parse error")
+        }
+    };
+    test.set_workspace_file(&["foo"], "foo").unwrap();
+    let workspace = match test.create_workspace(&[]) {
+        Ok(workspace) => workspace,
+        Err(err) => {
+            eprintln!(
+                "{}",
+                werk_parser::LocatedError {
+                    file_name: std::path::Path::new("input"),
+                    source_code: WERK,
+                    error: err
+                }
+            );
+            panic!("could not create workspace")
+        }
+    };
+    let globals = &workspace.manifest.globals;
+    assert_eq!(
+        globals
+            .get(&Symbol::new("exists-resolved"))
+            .unwrap()
+            .value
+            .value,
+        Value::String(test.workspace_path_str(["foo"]))
+    );
+    assert_eq!(
+        globals
+            .get(&Symbol::new("exists-explicit-out-dir"))
+            .unwrap()
+            .value
+            .value,
+        Value::String(test.output_path_str(["foo"]))
+    );
+    assert_eq!(
+        globals
+            .get(&Symbol::new("exists-explicit-workspace"))
+            .unwrap()
+            .value
+            .value,
+        Value::String(test.workspace_path_str(["foo"]))
+    );
+
+    assert_eq!(
+        globals
+            .get(&Symbol::new("exists-not-resolved"))
+            .unwrap()
+            .value
+            .value,
+        Value::String(test.output_path_str(["bar"]))
+    );
+    assert_eq!(
+        globals
+            .get(&Symbol::new("exists-not-explicit-out-dir"))
+            .unwrap()
+            .value
+            .value,
+        Value::String(test.output_path_str(["bar"]))
+    );
+    assert_eq!(
+        globals
+            .get(&Symbol::new("exists-not-explicit-workspace"))
+            .unwrap()
+            .value
+            .value,
+        Value::String(test.workspace_path_str(["bar"]))
+    );
+}
+
+/// When a build recipe depends on a file with the same name, that is not
+/// representable, and should cause a circular dependency error.
+#[apply(smol_macros::test)]
+async fn test_circular_dependency() {
+    static WERK: &str = r#"
+build "explicit" {
+    from "explicit"
+    run {
+        # Cannot get here.
+        copy "<in>" to "<out>"
+    }
+}
+    "#;
+    let test = Test::new(WERK).unwrap();
+    let workspace = test.create_workspace(&[]).unwrap();
+    let runner = Runner::new(&workspace);
+    match runner.build_or_run("explicit").await {
+        Ok(_) => panic!("expected circular dependency error"),
+        Err(werk_runner::Error::CircularDependency(chain)) => {
+            let id = TaskId::try_build("/explicit").unwrap();
+            let chain = chain.into_inner();
+            assert_eq!(chain, [id, id]);
+        }
+        Err(err) => panic!("unexpected error: {:?}", err),
+    }
+}
+
+/// When a directory in the workspace has the same name as the target of a build
+/// recipe, werk should not report a circular dependency
+#[apply(smol_macros::test)]
+async fn test_directory_name_collision() {
+    static WERK: &str = r#"
+# Directories should not participate in the lookup that happens as part
+# of build recipe matching.
+build "bar" {
+    info "<out>"
+}
+build "foo" {
+    info "<out>"
+}
+
+task build {
+    build ["foo", "bar"]
+}
+"#;
+
+    _ = tracing_subscriber::fmt::try_init();
+
+    let test = Test::new(WERK).unwrap();
+    test.set_workspace_dir(&["bar"]).unwrap();
+    assert!(test.io.contains_dir(test.workspace_path(["bar"])));
+    let workspace = test.create_workspace(&[]).unwrap();
+    let runner = Runner::new(&workspace);
+    match runner.build_or_run("build").await {
+        Ok(_) => panic!("expected error"),
+        Err(werk_runner::Error::Eval(werk_runner::EvalError::AmbiguousPathResolution(_, path))) => {
+            assert_eq!(path, Absolute::try_from("/bar").unwrap());
+        }
+        Err(err) => panic!("unexpected error: {err}"),
+    }
+}

--- a/werk-parser/ast/string.rs
+++ b/werk-parser/ast/string.rs
@@ -325,6 +325,8 @@ impl std::fmt::Display for Interpolation<'_> {
                         regex_interpolation_op.replacer
                     )?,
                     InterpolationOp::ResolveOsPath => unreachable!(),
+                    InterpolationOp::ResolveOutDir => f.write_str("out-dir")?,
+                    InterpolationOp::ResolveWorkspace => f.write_str("workspace")?,
                 }
             }
         }
@@ -398,6 +400,8 @@ pub enum InterpolationOp<'a> {
     // Interpret the string as an OS path and resolve it. This is the `<..>`
     // interpolation syntax.
     ResolveOsPath,
+    ResolveOutDir,
+    ResolveWorkspace,
 }
 
 impl InterpolationOp<'_> {
@@ -413,6 +417,8 @@ impl InterpolationOp<'_> {
             InterpolationOp::AppendEach(s) => InterpolationOp::AppendEach(s.into_owned().into()),
             InterpolationOp::RegexReplace(r) => InterpolationOp::RegexReplace(r.into_static()),
             InterpolationOp::ResolveOsPath => InterpolationOp::ResolveOsPath,
+            InterpolationOp::ResolveOutDir => InterpolationOp::ResolveOutDir,
+            InterpolationOp::ResolveWorkspace => InterpolationOp::ResolveWorkspace,
         }
     }
 }
@@ -427,7 +433,10 @@ impl SemanticHash for InterpolationOp<'_> {
             }
             InterpolationOp::PrependEach(s) | InterpolationOp::AppendEach(s) => s.hash(state),
             InterpolationOp::RegexReplace(r) => r.hash(state),
-            InterpolationOp::ResolveOsPath => (),
+            // Covered by discriminant.
+            InterpolationOp::ResolveOsPath
+            | InterpolationOp::ResolveOutDir
+            | InterpolationOp::ResolveWorkspace => (),
         }
     }
 }

--- a/werk-parser/error.rs
+++ b/werk-parser/error.rs
@@ -181,6 +181,8 @@ pub enum Failure {
     ExpectedKeyword(&'static &'static str),
     #[error("invalid escape sequence: {0:?}")]
     InvalidEscapeChar(char),
+    #[error("invalid interpolation operator")]
+    InvalidInterpolationOp,
     #[error("expected character {0}")]
     ExpectedChar(char),
     #[error(transparent)]

--- a/werk-runner/ir.rs
+++ b/werk-runner/ir.rs
@@ -3,7 +3,9 @@ use werk_fs::Absolute;
 use werk_parser::{ast, parser::Span};
 use werk_util::Symbol;
 
-use crate::{cache::Hash128, EvalError, GlobalVariables, Pattern, PatternMatchData};
+use crate::{
+    cache::Hash128, AmbiguousPatternError, EvalError, GlobalVariables, Pattern, PatternMatchData,
+};
 
 type Result<T, E = EvalError> = std::result::Result<T, E>;
 
@@ -30,7 +32,7 @@ impl<'a> Manifest<'a> {
     pub fn match_build_recipe<'b>(
         &'b self,
         path: &Absolute<werk_fs::Path>,
-    ) -> Result<Option<BuildRecipeMatch<'b>>, crate::Error> {
+    ) -> Result<Option<BuildRecipeMatch<'b>>, AmbiguousPatternError> {
         let matches = self.build_recipes.iter().filter_map(|recipe| {
             recipe
                 .pattern
@@ -69,12 +71,11 @@ impl<'a> Manifest<'a> {
                         _ => {
                             // Candidate and best have the same length, or both are
                             // exact.
-                            return Err(crate::AmbiguousPatternError {
+                            return Err(AmbiguousPatternError {
                                 pattern1: best_recipe.pattern.to_string(),
                                 pattern2: candidate_recipe.pattern.to_string(),
                                 path: path.to_string(),
-                            }
-                            .into());
+                            });
                         }
                     }
                 }

--- a/werk-runner/runner.rs
+++ b/werk-runner/runner.rs
@@ -1036,6 +1036,14 @@ pub struct OwnedDependencyChain {
     vec: Vec<TaskId>,
 }
 
+impl OwnedDependencyChain {
+    #[inline]
+    #[must_use]
+    pub fn into_inner(self) -> Vec<TaskId> {
+        self.vec
+    }
+}
+
 impl std::fmt::Display for OwnedDependencyChain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (i, task_id) in self.vec.iter().enumerate() {

--- a/werk-runner/workspace.rs
+++ b/werk-runner/workspace.rs
@@ -379,17 +379,6 @@ impl<'a> Workspace<'a> {
         self.io.create_parent_dirs(&fs_path).map_err(Into::into)
     }
 
-    /// Resolve abstract path. If the path exists in the workspace, return the
-    /// input file path. Otherwise, return the file path in the output
-    /// directory, regardless of whether it exists.
-    pub fn resolve_path(&self, path: &Absolute<werk_fs::Path>) -> Absolute<std::path::PathBuf> {
-        if self.workspace_files.contains_key(path) {
-            path.resolve(&self.project_root)
-        } else {
-            path.resolve(&self.output_directory)
-        }
-    }
-
     pub fn unresolve_path(
         &self,
         path: &Absolute<std::path::Path>,


### PR DESCRIPTION
Fixes #41 

The chosen solution is to fail with an error when path resolution is ambiguous, and provide a way to disambiguate path resolution using `"<foo:out-dir>"` or `"<foo:workspace>"`.