### PR TITLE
Fix print full error messages

### DIFF
--- a/werk-cli/main.rs
+++ b/werk-cli/main.rs
@@ -187,7 +187,11 @@ fn main() -> Result<(), Error> {
             .init(),
     }
 
-    smol::block_on(try_main(args))
+    if let Err(e) = smol::block_on(try_main(args)) {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+    Ok(())
 }
 
 async fn try_main(args: Args) -> Result<(), Error> {


### PR DESCRIPTION
When an error is raised, rather than printing the Rust enum short form (e.g. "NoWerkfile"), print the more descriptive error message (e.g. "Werkfile not found in this directory or any parent directory").